### PR TITLE
Ensure kdump runs never run this (CASMTRIAGE-3591)

### DIFF
--- a/93metaldmk8s/metal-dmk8s-genrules.sh
+++ b/93metaldmk8s/metal-dmk8s-genrules.sh
@@ -27,6 +27,14 @@
 
 command -v wait_for_dev > /dev/null 2>&1 || . /lib/dracut-lib.sh
 
+root=$(getarg root)
+case $root in 
+    kdump)
+        echo 'Not doing anything for kdump'
+        exit 0
+        ;;
+esac
+
 # Only run when luks is disabled and a deployment server is present.
 if ! getargbool 0 rd.luks -d -n rd_NO_LUKS; then
     if [ -n "${metal_server:-}" ]; then 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-<a name="metal-93dmk8s---persistent-kubernetes-device-maps-"></a>
 # METAL 93dmk8s - persistent kubernetes device-maps 
 
 This module deploys an ephemeral disk to be used by kubernetes containers:
@@ -9,23 +8,21 @@ This module deploys an ephemeral disk to be used by kubernetes containers:
 
 ## Table of Contents
 
-* [OverlayFS](README.md#overlayfs)
-* [Parameters](README.md#parameters)
-    * [Customizable Parameters](README.md#customizable-parameters) 
-        * [FSLabel Parameters](README.md#fslabel-parameters)
-          * [`metal.disk.conrun`](README.md#metaldiskconrun)
-          * [`metal.disk.conlib`](README.md#metaldiskconlib)
-          * [`metal.disk.k8slet`](README.md#metaldiskk8slet)
-        * [Partition Size Parameters](README.md#partition-size-parameters)
-          * [`metal.disk.conrun.size`](README.md#metaldiskconrunsize)
-          * [`metal.disk.conlib.size`](README.md#metaldiskconlibsize)
-          * [`metal.disk.k8slet.size`](README.md#metaldiskk8sletsize)
-    * [Required Parameters](README.md#required-parameters)
-      * [`metal.server`](README.md#metalserver)
+- [OverlayFS](README.md#overlayfs)
+- [Parameters](README.md#parameters)
+    - [Customizable Parameters](README.md#customizable-parameters) 
+        - [FSLabel Parameters](README.md#fslabel-parameters)
+            - [`metal.disk.conrun`](README.md#metaldiskconrun)
+            - [`metal.disk.conlib`](README.md#metaldiskconlib)
+            - [`metal.disk.k8slet`](README.md#metaldiskk8slet)
+        - [Partition Size Parameters](README.md#partition-size-parameters)
+            - [`metal.disk.conrun.size`](README.md#metaldiskconrunsize)
+            - [`metal.disk.conlib.size`](README.md#metaldiskconlibsize)
+            - [`metal.disk.k8slet.size`](README.md#metaldiskk8sletsize)
+    - [Required Parameters](README.md#required-parameters)
+    - [`metal.server`](README.md#metalserver)
 
-
-<a name="overlayfs"></a>
-# OverlayFS
+## OverlayFS
 
 In order to allow reading of the original material in `/var/lib/containerd` residing in the SquashFS image while offering persistent storage, an overlayFS is created.
 
@@ -37,79 +34,64 @@ Only `/var/lib/containerd` is an OverlayFS.
 
 For more information on the OverlayFS, see:
 - [90metalmdsquash](https://github.com/Cray-HPE/dracut-metal-mdsquash#rootfs-and-the-persistent-overlayfs)
-- [CSM Usage of OverlayFS](https://github.com/Cray-HPE/docs-csm-install/blob/main/104-NCN-PARTITIONING.md#overlayfs-and-persistence)
+- [CSM Usage of OverlayFS](https://github.com/Cray-HPE/docs-csm/blob/main/background/ncn_mounts_and_file_systems.md)
 - [Kernel Documentation on OverlayFS](https://www.kernel.org/doc/html/latest/filesystems/overlayfs.html)
 
-<a name="parameters"></a>
-# Parameters
+## Parameters
 
 The `unit` of size varies per-parameter; pay attention to avoid undesirable partition tables
 
-a name="customizable-parameters"></a>
-## Customizable Parameters
+### Customizable Parameters
 
-<a name="fslabel-parameters"></a>
 ### FSLabel Parameters
 
 The FS labels can be changed from their default values.
 This may be desirable for cases when another LVM is being re-used.
 
-<a name="`metal.disk.conrun`"></a>
 ##### `metal.disk.conrun`
 
 > FSLabel for the `/run/containerd`.
 > default: CONRUN
 
-<a name="`metal.disk.conlib`"></a>
 ##### `metal.disk.conlib`
 
 > FSLabel for the `/run/lib-containerd`.
-> * default CONLIB
+> - `Default CONLIB`
 
-<a name="`metal.disk.k8slet`"></a>
 ##### `metal.disk.k8slet`
 
 > FSLabel for the `/var/lib/kubelet`.
-> * default: K8SLET
+> - `Default: K8SLET`
 
-<a name="partition-size-parameters"></a>
 ### Partition Size Parameters
 
-<a name="`metal.disk.conrun.siz`"></a>
 ##### `metal.disk.conrun.size`
 
 > Size of the `/run/containerd` partition, measured in gigabytes (`GB`):
-> 
-> * default: 75
-> * min: 10
-> * max: 150
+> - `Default: 75`
+> - `Min: 10`
+> - `Max: 150`
 
-<a name="`metal.disk.conlib.size`-"></a>
 ##### `metal.disk.conlib.size` 
 
 > Size of the `/run/lib-containerd` partition, measured in percentage (`%`):
-> 
-> * default: 40
-> * min: 10
-> * max: 45
+> - `Default: 40`
+> - `Min: 10`
+> - `Max: 45`
 
-<a name="`metal.disk.k8slet.size`"></a>
 ##### `metal.disk.k8slet.size`
 
 > Size of the `/var/lib/kubelet` partition, measured in percentage (`%`):
-> 
-> * default: 10
-> * min: 10
-> * max: 45
+> - `Default: 10`
+> - `Min: 10`
+> - `Max: 45`
 
-<a name="required-parameters"></a>
-## Required Parameters
+### Required Parameters
 
 The following parameters are required for this module to work, however they belong to the native dracut space.
 
 > See [`module-setup.sh`](./93metaldmk8s/module-setup.sh) for the full list of module and driver dependencies.
 
-<a name="`metal.server`"></a>
 ##### `metal.server`
 
 > Enable or disable this module. This parameter has no other effect on 93dmk8s other than indicating that the active node is currently (re)building and requires partitions.


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: CASMTRIAGE-3591

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
Ensure kdump never runs if a kdump initrd is built without omitting this module it'll exit safely.

Tidy up the README.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
Less risk incase a non-CSM initrd is created without omitting this module.