### PR TITLE
Ensure kdump runs never runs this module (CASMTRIAGE-3591)

### DIFF
--- a/93metaldmk8s/metal-dmk8s-genrules.sh
+++ b/93metaldmk8s/metal-dmk8s-genrules.sh
@@ -27,6 +27,14 @@
 
 command -v wait_for_dev > /dev/null 2>&1 || . /lib/dracut-lib.sh
 
+root=$(getarg root)
+case $root in 
+    kdump)
+        echo 'Not doing anything for kdump'
+        exit 0
+        ;;
+esac
+
 # Only run when luks is disabled and a deployment server is present.
 if ! getargbool 0 rd.luks -d -n rd_NO_LUKS; then
     if [ -n "${metal_server:-}" ]; then 


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: CASMTRIAGE-3591

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
This ensures that if this module is not omitted from a kdump initrd that it will cease and desist all actions.


### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
