### PR TITLE
MTL-1839 Ensure Early Exit on KDUMP

### DIFF
--- a/93metaldmk8s/metal-dmk8s-genrules.sh
+++ b/93metaldmk8s/metal-dmk8s-genrules.sh
@@ -25,6 +25,15 @@
 # metal-dmk8s-genrules.sh
 [ "${metal_debug:-0}" = 0 ] || set -x
 
+command -v getarg > /dev/null 2>&1 || . /lib/dracut-lib.sh
+
+case "$(getarg root)" in 
+    kdump)
+        # do not do anything for kdump
+        exit 0
+        ;;
+esac
+
 command -v wait_for_dev > /dev/null 2>&1 || . /lib/dracut-lib.sh
 
 # Only run when luks is disabled and a deployment server is present.


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-1839
- Relates to: CASMTRIAGE-3591

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
Remove the need to remember to omit this module during kdump initrd generation.

##### k8s-worker example

```bash
ncn-w002:~ # echo c >/proc/sysrq-trigger
[  187.699830] sysrq: Trigger a crash
[  187.703239] Kernel panic - not syncing: sysrq triggered crash
[  187.708989] CPU: 59 PID: 17578 Comm: bash Kdump: loaded Tainted: G               X    5.3.18-150300.59.76-default #1 SLE15-SP3
[  187.720374] Hardware name: Intel Corporation S2600WFT/S2600WFT, BIOS SE5C620.86B.02.01.0012.C0001.070720200218 07/07/2020
[  187.731313] Call Trace:
[  187.733776]  dump_stack+0x66/0x8b
[  187.737097]  panic+0xfe/0x2d7
[  187.740072]  ? printk+0x52/0x6e
[  187.743216]  sysrq_handle_crash+0x11/0x20
[  187.747228]  __handle_sysrq+0x89/0x140
[  187.750982]  write_sysrq_trigger+0x2b/0x30
[  187.755082]  proc_reg_write+0x39/0x60
[  187.758745]  vfs_write+0xad/0x1b0
[  187.762064]  ksys_write+0xa1/0xe0
[  187.765384]  do_syscall_64+0x5b/0x1e0
[  187.769049]  entry_SYSCALL_64_after_hwframe+0x44/0xa9
[  187.774103] RIP: 0033:0x7fc069d02b13
[  187.777682] Code: 0f 1f 80 00 00 00 00 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 64 8b 04 25 18 00 00 00 85 c0 75 14 b8 01 00 00 00 0f 05 <48> 3d 00 f0 ff ff 77 55 f3 c3 0f 1f 00 41 54 55 49 89 d4 53 48 89
[  187.796427] RSP: 002b:00007fff5ab1dd98 EFLAGS: 00000246 ORIG_RAX: 0000000000000001
[  187.803989] RAX: ffffffffffffffda RBX: 0000000000000002 RCX: 00007fc069d02b13
[  187.811124] RDX: 0000000000000002 RSI: 000055f2bb531920 RDI: 0000000000000001
[  187.818254] RBP: 000055f2bb531920 R08: 000000000000000a R09: 0000000000000000
[  187.825388] R10: 00007fc069c03468 R11: 0000000000000246 R12: 00007fc069fe6500
[  187.832518] R13: 0000000000000002 R14: 00007fc069febc00 R15: 0000000000000002
[    0.112074] [Firmware Bug]: the BIOS has corrupted hw-PMU resources (MSR 38d is b0)
�[    2.134001] mce: Unable to init MCE device (rc: -5)
[   11.062835] dracut-pre-mount[579]: skipping keystore management (no LUKS; rd.luks=0 was set on the cmdline)
Unable to ioctl(KDSETLED) -- are you not on the console? (Inappropriate ioctl for device)
mount: /kdump/rootfsbase: cannot remount /kdump/live/LiveOS/filesystem.squashfs read-write, is write-protected.
Nothing to delete in /kdump/overlay/LiveOS/overlay-SQFSRAID-8842f8d4-72db-410d-9e19-169703ce08ce/var/crash.
Extracting dmesg
-------------------------------------------------------------------------------

The dmesg log is saved to /kdump/overlay/LiveOS/overlay-SQFSRAID-8842f8d4-72db-410d-9e19-169703ce08ce/var/crash/2022-07-08-21:22/dmesg.txt.

makedumpfile Completed.
-------------------------------------------------------------------------------
Saving dump using makedumpfile
-------------------------------------------------------------------------------
Copying data                                      : [100.0 %] \           eta: 0s

The dumpfile is saved to /kdump/overlay/LiveOS/overlay-SQFSRAID-8842f8d4-72db-410d-9e19-169703ce08ce/var/crash/2022-07-08-21:22/vmcore.

makedumpfile Completed.
-------------------------------------------------------------------------------
Generating README              Finished.
Copying System.map             Finished.
Copying kernel                 Finished.
umount: /kdump/overlay: not mounted.
umount: /kdump/rootfsbase: not mounted.
umount: /kdump/live: not mounted.
umount: /sys/fs/cgroup/unified: target is busy.
umount: /sys/fs/cgroup: target is busy.
umount: /run: target is busy.
umount: /dev: target is busy.
umount: /: not mounted.
Rebooting.
[   82.110437] reboot: Restarting system
```

Mounts came up fine for diskboots and netboots
```bash
ncn-w002:~ # lsblk
NAME                       MAJ:MIN RM   SIZE RO TYPE  MOUNTPOINT
loop0                        7:0    0   5.3G  1 loop  /run/rootfsbase
loop1                        7:1    0   3.2G  0 loop
└─live-overlay-pool        254:0    0    32G  0 dm
loop2                        7:2    0    32G  0 loop
└─live-overlay-pool        254:0    0    32G  0 dm
sda                          8:0    0 447.1G  0 disk
├─sda1                       8:1    0   476M  0 part
│ └─md124                    9:124  0 475.9M  0 raid1 /metal/recovery
├─sda2                       8:2    0  22.8G  0 part
│ └─md126                    9:126  0  22.8G  0 raid1 /run/initramfs/live
├─sda3                       8:3    0 139.7G  0 part
│ └─md125                    9:125  0 139.6G  0 raid1 /run/initramfs/overlayfs
└─sda4                       8:4    0 139.7G  0 part
  └─md127                    9:127  0 279.1G  0 raid0
    └─metalvg0-CRAYS3CACHE 254:1    0   200G  0 lvm   /var/lib/s3fs_cache
sdb                          8:16   0 447.1G  0 disk
├─sdb1                       8:17   0   476M  0 part
│ └─md124                    9:124  0 475.9M  0 raid1 /metal/recovery
├─sdb2                       8:18   0  22.8G  0 part
│ └─md126                    9:126  0  22.8G  0 raid1 /run/initramfs/live
├─sdb3                       8:19   0 139.7G  0 part
│ └─md125                    9:125  0 139.6G  0 raid1 /run/initramfs/overlayfs
└─sdb4                       8:20   0 139.7G  0 part
  └─md127                    9:127  0 279.1G  0 raid0
    └─metalvg0-CRAYS3CACHE 254:1    0   200G  0 lvm   /var/lib/s3fs_cache
sdc                          8:32   0   1.7T  0 disk
├─sdc1                       8:33   0  69.8G  0 part  /run/containerd
├─sdc2                       8:34   0 645.5G  0 part  /run/lib-containerd
└─sdc3                       8:35   0 178.8G  0 part  /var/lib/kubelet
```


### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
