### PR TITLE
MTL-1852 Use partprobe before mkfs

### DIFF
--- a/93metaldmk8s/module-setup.sh
+++ b/93metaldmk8s/module-setup.sh
@@ -45,7 +45,7 @@ installkernel() {
 install() {
     # the rest is needed by metal-squashfs-url-dract.
     # rmdir is needed by dmsquash-live/livenet
-    inst_multiple chmod lsblk mkfs.xfs parted sort tail
+    inst_multiple chmod lsblk mkfs.xfs parted partprobe sort tail
 
     inst_simple "$moddir/metal-dmk8s-lib.sh" "/lib/metal-dmk8s-lib.sh"
     inst_script "$moddir/metal-dmk8s-disks.sh" /sbin/metal-dmk8s-disks


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-1852

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
Add `partprobe` calls before each `mkfs.xfs` call to help load FS changes. On Gigabyte hardware we've encountered issues where `mkfs.xfs` was invoked "too quickly" after the `parted` calls, resulting in failed boots.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)

Tested on `drax`, `Gigabyte`,

### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
This should be enough to fix the problem, otherwise if the problem comes up again we should resort to using `sleep 2`. `sleep` is not ideal because it is ambiguous and doesn't guarantee anything is actually ready, `partprobe` should work for us. I say "should" because this problem is coming about randomly, and is hard to test.