### PR TITLE
MTL-1924 Fix `partprobe` when `nvme` is present

### DIFF
--- a/93metaldmk8s/metal-dmk8s-lib.sh
+++ b/93metaldmk8s/metal-dmk8s-lib.sh
@@ -85,18 +85,18 @@ make_ephemeral() {
 
     # NVME partitions have a "p" to delimit the partition number.
     if [[ "$target" =~ "nvme" ]]; then
-        target="${target}p" 
+        nvme=1
     fi
 
     partprobe "/dev/${target}"
     _trip_udev
-    mkfs.xfs -f -L ${metal_conrun#*=} "/dev/${target}1" || metal_dmk8s_die "Failed to create ${metal_conrun#*=}"
+    mkfs.xfs -f -L ${metal_conrun#*=} "/dev/${target}${nvme:+p}1" || metal_dmk8s_die "Failed to create ${metal_conrun#*=}"
     partprobe "/dev/${target}"
     _trip_udev
-    mkfs.xfs -f -L ${metal_conlib#*=} "/dev/${target}2" || metal_dmk8s_die "Failed to create ${metal_conlib#*=}"
+    mkfs.xfs -f -L ${metal_conlib#*=} "/dev/${target}${nvme:+p}2" || metal_dmk8s_die "Failed to create ${metal_conlib#*=}"
     partprobe "/dev/${target}"
     _trip_udev
-    mkfs.xfs -f -L ${metal_k8slet#*=} "/dev/${target}3" || metal_dmk8s_die "Failed to create ${metal_k8slet#*=}"
+    mkfs.xfs -f -L ${metal_k8slet#*=} "/dev/${target}${nvme:+p}3" || metal_dmk8s_die "Failed to create ${metal_k8slet#*=}"
 
     mkdir -p /run/containerd /var/lib/kubelet /var/lib/containerd /run/lib-containerd
     {


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-1924

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
MTL-1852 added `partprobe` calls, but these were never tested with the existing NVME support. The variable change for `$target` breaks the `partprobe` calls when NVME is used, this is minor but prevents the proactive partition table refresh from occurring.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
