### PR TITLE
MTL-1708 Build & Publish SP4 RPMs

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -25,9 +25,8 @@
  */
 @Library('csm-shared-library') _
 
-def sleImage = 'artifactory.algol60.net/csm-docker/stable/csm-docker-sle'
-def sleVersion = '15.3'
 def isStable = env.TAG_NAME != null ? true : false
+def sleImage = 'artifactory.algol60.net/csm-docker/stable/csm-docker-sle'
 pipeline {
 
     agent {
@@ -48,39 +47,77 @@ pipeline {
 
     stages {
 
-        stage('Prepare: RPMs') {
-            agent {
-                docker {
-                    image "${sleImage}:${sleVersion}"
-                    reuseNode true
-                }
-            }
-            steps {
-                runLibraryScript("addRpmMetaData.sh", "${env.NAME}.spec")
-                sh "make prepare"
-                sh "git update-index --assume-unchanged ${env.NAME}.spec"
-            }
-        }
+        stage('Build & Publish') {
 
-        stage('Build: RPM') {
-            agent {
-                docker {
-                    image "${sleImage}:${sleVersion}"
-                    reuseNode true
-                }
-            }
-            steps {
-                sh "make rpm"
-            }
-        }
+            matrix {
 
-        stage('Publish') {
-            steps {
-                script {
-                    publishCsmRpms(component: env.NAME, pattern: "dist/rpmbuild/RPMS/noarch/*.rpm", os: "sle-15sp2", arch: "noarch", isStable: isStable)
-                    publishCsmRpms(component: env.NAME, pattern: "dist/rpmbuild/RPMS/noarch/*.rpm", os: "sle-15sp3", arch: "noarch", isStable: isStable)
-                    publishCsmRpms(component: env.NAME, pattern: "dist/rpmbuild/SRPMS/*.rpm", os: "sle-15sp2", arch: "src", isStable: isStable)
-                    publishCsmRpms(component: env.NAME, pattern: "dist/rpmbuild/SRPMS/*.rpm", os: "sle-15sp3", arch: "src", isStable: isStable)
+                agent {
+                    node {
+                        label "metal-gcp-builder"
+                        customWorkspace "${env.WORKSPACE}/${sleVersion}"
+                    }
+                }
+
+                axes {
+                    axis {
+                        name 'sleVersion'
+                        values 15.3, 15.4
+                    }
+                }
+
+                stages {
+
+                    stage('Prepare: RPMs') {
+                        agent {
+                            docker {
+                                label 'docker'
+                                reuseNode true
+                                image "${sleImage}:${sleVersion}"
+                            }
+                        }
+                        steps {
+                            runLibraryScript("addRpmMetaData.sh", "${env.NAME}.spec")
+                            sh "make prepare"
+                            sh "git update-index --assume-unchanged ${env.NAME}.spec"
+                        }
+                    }
+
+                    stage('Build: RPMs') {
+                        agent {
+                            docker {
+                                label 'docker'
+                                reuseNode true
+                                image "${sleImage}:${sleVersion}"
+                            }
+                        }
+                        steps {
+                            sh "make rpm"
+                        }
+                    }
+
+                    stage('Publish: RPMs') {
+                        steps {
+                            script {
+                                sles_version_parts = "${sleVersion}".tokenize('.')
+                                sles_major = "${sles_version_parts[0]}"
+                                sles_minor = "${sles_version_parts[1]}"
+                                publishCsmRpms(
+                                        arch: "noarch",
+                                        component: env.NAME,
+                                        isStable: isStable,
+                                        os: "sle-${sles_major}sp${sles_minor}",
+                                        pattern: "dist/rpmbuild/RPMS/noarch/*.rpm",
+                                )
+                                publishCsmRpms(
+                                        arch: "src",
+                                        component: env.NAME,
+                                        isStable: isStable,
+                                        os: "sle-${sles_major}sp${sles_minor}",
+                                        pattern: "dist/rpmbuild/SRPMS/*.rpm",
+                                )
+                            }
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: MTL-1708

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
Continue to build and publish SP3 RPMs while publishing SP4 RPMs. Include the correct, respective metadata in each RPM.

The SLES 15SP3 build creates an RPM with SP3 metadata and publishes it to `sle-15sp3`:

```bash
Name        : dracut-metal-dmk8s
Version     : 2.0.5~2~g07a4780
Release     : 1
Architecture: noarch
Install Date: (not installed)
Group       : System/Management
Size        : 18440
License     : MIT License
Signature   : (none)
Source RPM  : dracut-metal-dmk8s-2.0.5~2~g07a4780-1.src.rpm
Build Date  : Wed Nov 30 22:32:01 2022
Build Host  : 873023c54f74
Relocations : (not relocatable)
Packager    : <doomslayer@hpe.com>
Vendor      : Cray HPE
URL         : https://github.com/Cray-HPE/dracut-metal-dmk8s.git
Summary     : Dracut module for setting up an ephemeral disk as kubernetes container storage.
Description :
Git Repository: dracut-metal-dmk8s
Git Branch: MTL-1708-SP4
Git Commit Revision: 07a4780f
Git Commit Timestamp: Wed Nov 30 13:12:52 2022 -0600
Distribution: SUSE Linux Enterprise Server 15 SP3
```

The SLES 15SP4 build creates an RPM with SP4 metadata, and publishes it to `sle-15sp4`:

```bash
Name        : dracut-metal-dmk8s
Version     : 2.0.5~2~g07a4780
Release     : 1
Architecture: noarch
Install Date: (not installed)
Group       : System/Management
Size        : 18440
License     : MIT License
Signature   : (none)
Source RPM  : dracut-metal-dmk8s-2.0.5~2~g07a4780-1.src.rpm
Build Date  : Wed Nov 30 22:32:04 2022
Build Host  : 6a900db9f9a0
Relocations : (not relocatable)
Packager    : <doomslayer@hpe.com>
Vendor      : Cray HPE
URL         : https://github.com/Cray-HPE/dracut-metal-dmk8s.git
Summary     : Dracut module for setting up an ephemeral disk as kubernetes container storage.
Description :
Git Repository: dracut-metal-dmk8s
Git Branch: MTL-1708-SP4
Git Commit Revision: 07a4780f
Git Commit Timestamp: Wed Nov 30 13:12:52 2022 -0600
Distribution: SUSE Linux Enterprise Server 15 SP4
```

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!---
    Example:
    
    This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
    is resolved and the overall risk of fatal failures is reduced.
    
    -->
